### PR TITLE
Add basic primitive mesh generation

### DIFF
--- a/src/primitives.h
+++ b/src/primitives.h
@@ -1,0 +1,81 @@
+#pragma once
+#include <vector>
+#include <glm/glm.hpp>
+#include "vk_types.h"
+
+namespace primitives {
+
+inline void buildCube(std::vector<Vertex>& vertices, std::vector<uint32_t>& indices) {
+    vertices.clear();
+    indices.clear();
+
+    struct Face {
+        glm::vec3 normal;
+        glm::vec3 v0, v1, v2, v3;
+    } faces[6] = {
+        { {0,0,1}, { -0.5f,-0.5f, 0.5f}, { 0.5f,-0.5f, 0.5f}, { -0.5f, 0.5f, 0.5f}, { 0.5f, 0.5f, 0.5f} },
+        { {0,0,-1},{ -0.5f,-0.5f,-0.5f}, { -0.5f, 0.5f,-0.5f}, { 0.5f,-0.5f,-0.5f}, { 0.5f, 0.5f,-0.5f} },
+        { {0,1,0}, { -0.5f, 0.5f, 0.5f}, { 0.5f, 0.5f, 0.5f}, { -0.5f, 0.5f,-0.5f}, { 0.5f, 0.5f,-0.5f} },
+        { {0,-1,0},{ -0.5f,-0.5f, 0.5f}, { -0.5f,-0.5f,-0.5f}, { 0.5f,-0.5f, 0.5f}, { 0.5f,-0.5f,-0.5f} },
+        { {1,0,0}, { 0.5f,-0.5f, 0.5f}, { 0.5f,-0.5f,-0.5f}, { 0.5f, 0.5f, 0.5f}, { 0.5f, 0.5f,-0.5f} },
+        { {-1,0,0},{ -0.5f,-0.5f, 0.5f}, { -0.5f, 0.5f, 0.5f}, { -0.5f,-0.5f,-0.5f}, { -0.5f, 0.5f,-0.5f} }
+    };
+
+    for (auto& f : faces) {
+        uint32_t start = (uint32_t)vertices.size();
+        Vertex v0{f.v0, 0, f.normal, 0, glm::vec4(1.0f)};
+        Vertex v1{f.v1, 1, f.normal, 0, glm::vec4(1.0f)};
+        Vertex v2{f.v2, 0, f.normal, 1, glm::vec4(1.0f)};
+        Vertex v3{f.v3, 1, f.normal, 1, glm::vec4(1.0f)};
+        vertices.push_back(v0);
+        vertices.push_back(v1);
+        vertices.push_back(v2);
+        vertices.push_back(v3);
+        indices.push_back(start + 0);
+        indices.push_back(start + 1);
+        indices.push_back(start + 2);
+        indices.push_back(start + 2);
+        indices.push_back(start + 1);
+        indices.push_back(start + 3);
+    }
+}
+
+inline void buildSphere(std::vector<Vertex>& vertices, std::vector<uint32_t>& indices, int sectors = 16, int stacks = 16) {
+    vertices.clear();
+    indices.clear();
+    float radius = 0.5f;
+    for (int i = 0; i <= stacks; ++i) {
+        float v = (float)i / stacks;
+        float phi = v * glm::pi<float>();
+        float y = cos(phi);
+        float r = sin(phi);
+        for (int j = 0; j <= sectors; ++j) {
+            float u = (float)j / sectors;
+            float theta = u * glm::two_pi<float>();
+            float x = r * cos(theta);
+            float z = r * sin(theta);
+            Vertex vert;
+            vert.position = glm::vec3(x, y, z) * radius;
+            vert.normal = glm::normalize(glm::vec3(x, y, z));
+            vert.uv_x = u;
+            vert.uv_y = 1.0f - v;
+            vert.color = glm::vec4(1.0f);
+            vertices.push_back(vert);
+        }
+    }
+    for (int i = 0; i < stacks; ++i) {
+        for (int j = 0; j < sectors; ++j) {
+            uint32_t first = i * (sectors + 1) + j;
+            uint32_t second = first + sectors + 1;
+            indices.push_back(first);
+            indices.push_back(second);
+            indices.push_back(first + 1);
+            indices.push_back(first + 1);
+            indices.push_back(second);
+            indices.push_back(second + 1);
+        }
+    }
+}
+
+} // namespace primitives
+

--- a/src/vk_engine.cpp
+++ b/src/vk_engine.cpp
@@ -16,6 +16,7 @@
 #include <vk_pipelines.h>
 #include <iostream>
 #include <glm/gtx/transform.hpp>
+#include "primitives.h"
 
 #define VMA_IMPLEMENTATION
 
@@ -151,6 +152,82 @@ void VulkanEngine::init_default_data()
     sampl.magFilter = VK_FILTER_LINEAR;
     sampl.minFilter = VK_FILTER_LINEAR;
     vkCreateSampler(_device, &sampl, nullptr, &_defaultSamplerLinear);
+
+    //create a simple white material that we can use for generated meshes
+    GLTFMetallic_Roughness::MaterialResources matResources{};
+    matResources.colorImage = _whiteImage;
+    matResources.colorSampler = _defaultSamplerLinear;
+    matResources.metalRoughImage = _whiteImage;
+    matResources.metalRoughSampler = _defaultSamplerLinear;
+
+    AllocatedBuffer matBuffer = create_buffer(sizeof(GLTFMetallic_Roughness::MaterialConstants),
+                                              VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+                                              VMA_MEMORY_USAGE_CPU_TO_GPU);
+    auto *matConstants = (GLTFMetallic_Roughness::MaterialConstants *) matBuffer.allocation->GetMappedData();
+    *matConstants = {};
+    matConstants->colorFactors = glm::vec4(1.0f);
+    matResources.dataBuffer = matBuffer.buffer;
+    matResources.dataBufferOffset = 0;
+
+    auto defaultMaterial = std::make_shared<GLTFMaterial>();
+    defaultMaterial->data = metalRoughMaterial.write_material(_device, MaterialPass::MainColor,
+                                                             matResources, globalDescriptorAllocator);
+
+    //build cube mesh
+    {
+        std::vector<Vertex> verts;
+        std::vector<uint32_t> inds;
+        primitives::buildCube(verts, inds);
+
+        cubeMesh = std::make_shared<MeshAsset>();
+        cubeMesh->name = "Cube";
+        cubeMesh->meshBuffers = uploadMesh(inds, verts);
+
+        GeoSurface surf{};
+        surf.startIndex = 0;
+        surf.count = (uint32_t) inds.size();
+        surf.material = defaultMaterial;
+        surf.bounds.origin = glm::vec3(0.0f);
+        surf.bounds.extents = glm::vec3(0.5f);
+        surf.bounds.sphereRadius = glm::length(surf.bounds.extents);
+        cubeMesh->surfaces.push_back(surf);
+
+        testMeshes.push_back(cubeMesh);
+
+        _mainDeletionQueue.push_function([&, buffers = cubeMesh->meshBuffers]() {
+            destroy_buffer(buffers.indexBuffer);
+            destroy_buffer(buffers.vertexBuffer);
+        });
+    }
+
+    //build sphere mesh
+    {
+        std::vector<Vertex> verts;
+        std::vector<uint32_t> inds;
+        primitives::buildSphere(verts, inds);
+
+        sphereMesh = std::make_shared<MeshAsset>();
+        sphereMesh->name = "Sphere";
+        sphereMesh->meshBuffers = uploadMesh(inds, verts);
+
+        GeoSurface surf{};
+        surf.startIndex = 0;
+        surf.count = (uint32_t) inds.size();
+        surf.material = defaultMaterial;
+        surf.bounds.origin = glm::vec3(0.0f);
+        surf.bounds.extents = glm::vec3(0.5f);
+        surf.bounds.sphereRadius = glm::length(surf.bounds.extents);
+        sphereMesh->surfaces.push_back(surf);
+
+        testMeshes.push_back(sphereMesh);
+
+        _mainDeletionQueue.push_function([&, buffers = sphereMesh->meshBuffers]() {
+            destroy_buffer(buffers.indexBuffer);
+            destroy_buffer(buffers.vertexBuffer);
+        });
+    }
+
+    _mainDeletionQueue.push_function([=]() { destroy_buffer(matBuffer); });
 
     _mainDeletionQueue.push_function([&]() {
         vkDestroySampler(_device, _defaultSamplerNearest, nullptr);
@@ -640,6 +717,34 @@ void VulkanEngine::update_scene()
     mainCamera.update();
 
     loadedScenes["structure"]->Draw(glm::mat4{1.f}, mainDrawContext);
+
+    if (cubeMesh)
+    {
+        const GeoSurface &surf = cubeMesh->surfaces[0];
+        RenderObject obj{};
+        obj.indexCount = surf.count;
+        obj.firstIndex = surf.startIndex;
+        obj.indexBuffer = cubeMesh->meshBuffers.indexBuffer.buffer;
+        obj.vertexBufferAddress = cubeMesh->meshBuffers.vertexBufferAddress;
+        obj.material = &surf.material->data;
+        obj.bounds = surf.bounds;
+        obj.transform = glm::translate(glm::mat4(1.f), glm::vec3(-2.f, 0.f, -2.f));
+        mainDrawContext.OpaqueSurfaces.push_back(obj);
+    }
+
+    if (sphereMesh)
+    {
+        const GeoSurface &surf = sphereMesh->surfaces[0];
+        RenderObject obj{};
+        obj.indexCount = surf.count;
+        obj.firstIndex = surf.startIndex;
+        obj.indexBuffer = sphereMesh->meshBuffers.indexBuffer.buffer;
+        obj.vertexBufferAddress = sphereMesh->meshBuffers.vertexBufferAddress;
+        obj.material = &surf.material->data;
+        obj.bounds = surf.bounds;
+        obj.transform = glm::translate(glm::mat4(1.f), glm::vec3(2.f, 0.f, -2.f));
+        mainDrawContext.OpaqueSurfaces.push_back(obj);
+    }
 
     glm::mat4 view = mainCamera.getViewMatrix();
 

--- a/src/vk_engine.h
+++ b/src/vk_engine.h
@@ -189,10 +189,13 @@ public:
 	VkPipelineLayout _meshPipelineLayout;
 	VkPipeline _meshPipeline;
 
-	GPUMeshBuffers rectangle;
-	DrawContext drawCommands;
+        GPUMeshBuffers rectangle;
+        DrawContext drawCommands;
 
-	std::vector<std::shared_ptr<MeshAsset> > testMeshes;
+        std::vector<std::shared_ptr<MeshAsset> > testMeshes;
+
+        std::shared_ptr<MeshAsset> cubeMesh;
+        std::shared_ptr<MeshAsset> sphereMesh;
 
 
 	// immediate submit structures


### PR DESCRIPTION
## Summary
- add new `primitives.h` header with helper functions to build cube and sphere vertices
- generate cube and sphere meshes in `init_default_data`
- render the generated primitives in `update_scene`

## Testing
- `cmake ..` *(fails: Could NOT find Vulkan)*

------
https://chatgpt.com/codex/tasks/task_e_684e5b6ed298832eaa0d8cf764cb7288